### PR TITLE
Update README and README.md to list pdf2svg as an external dependency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+.idea

--- a/README
+++ b/README
@@ -17,6 +17,10 @@ to test (and ultimately use) at
 
    pip install opentaxforms
 
+- **External dependencies**
+
+  [pdf2svg](https://github.com/dawbarton/pdf2svg)
+
 -  **Github**
 
    -  `code <https://github.com/jsaponara/opentaxforms/>`__

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ at [OpenTaxForms.org](http://OpenTaxForms.org/).
 
 	pip install opentaxforms
 
+  - **External dependencies**
+
+  [pdf2svg](https://github.com/dawbarton/pdf2svg)
+
   - **Github**
 
     - [code](https://github.com/jsaponara/opentaxforms/)


### PR DESCRIPTION
* Noticed that I needed pdf2svg to get tests to run locally.